### PR TITLE
Setup JavaScript ecosystem with Babelify for ES6 goodness and add breakpoint module

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/node_modules
+/build

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 /node_modules
 /build
 /javascript/tests
+/scripts

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /node_modules
 /build
+/javascript/tests

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "airbnb",
+  "env": {
+    "browser": true,
+    "jquery": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
   - "6"
-  - "5"
-  - "4"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 A collection of front end files to kickstart projects.
 
-...currently just SASS.
-
 ## Installation
 `npm install catchdigital/catchify --save`
 
@@ -21,16 +19,15 @@ Recommended Project SASS Directory Structure:
 ```
 
 ### Import SCSS files
-:bulb: Remember to replace `__NODE_MODULES_DIR__` to the actual relative path in your project
 
 ```sass
 // Catchify Includes (variables, mixins etc)
-@import '__NODE_MODULES_DIR__/catchify/sass/includes/includes';
+@import 'catchify/sass/includes/includes';
 // Project Includes
 @import 'includes/includes';
 
 // Catchify Base (grid, scaffolding and other global CSS)
-@import '__NODE_MODULES_DIR__/catchify/sass/includes/base';
+@import 'catchify/sass/includes/base';
 // Project Base
 @import 'includes/base';
 
@@ -38,7 +35,42 @@ Recommended Project SASS Directory Structure:
 @import 'components/components';
 
 // Catchify Helpers (override classes that act as the 'glue' etc)
-@import '__NODE_MODULES_DIR__/catchify/sass/includes/base/helpers';
+@import 'catchify/sass/includes/base/helpers';
 // Project Helpers
 @import 'includes/base/helpers';
+```
+
+### Build SASS
+:bulb: It's recommended that you pop these scripts in your pacakge JSON for convenience
+
+With Catchfiy as a dependency, simply point to where you want to build the CSS (directory and file path)
+```
+node ./node_modules/catchify/scripts/css.js ./node_modules ./sass/styles.scss BUILD_DIR BUILD_CSS_FILE
+```
+
+## JavaScript Setup
+
+:bulb: jQuery is a dependency unless otherwise stated...
+
+Recommended Project SASS Directory Structure:
+```
+/javascript/lib/module.js
+/javascript/index.js
+```
+
+### Import ES6 module files
+
+```javascript
+import catchify from 'catchify';
+
+// Use Catchfiy.breakpoint
+catchify.breakpoint.init();
+```
+
+### Build JavaScript
+:bulb: It's recommended that you pop these scripts in your pacakge JSON for convenience
+
+With Catchfiy as a dependency, simply point to where you want to build the Javascript (file path)
+```
+node ./node_modules/catchify/scripts/js.js ./node_modules ./javascript/index.js BUILD_JS_FILE
 ```

--- a/examples/breakpoint.html
+++ b/examples/breakpoint.html
@@ -7,11 +7,11 @@
   <link rel="stylesheet" type="text/css" href="../build/styles.css">
 </head>
 <body>
-  <div class="container">
+  <div class="container buffer-lg">
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
         <h1>Breakpoint module example:</h1>
-        <p>Currently listenting using <code>breakpoint.onChange()</code></p>
+        <p>Currently listening to custom breakpoint events</p>
 
         <pre>Current Breakpoint: (<b data-breakpoint-output></b>)</pre>
       </div>

--- a/examples/breakpoint.html
+++ b/examples/breakpoint.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Catchify Breakpoint Example</title>
+  <link rel="stylesheet" type="text/css" href="../build/styles.css">
+</head>
+<body>
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
+        <h1>Breakpoint module example:</h1>
+        <p>Currently listenting using <code>breakpoint.onChange()</code></p>
+
+        <pre>Current Breakpoint: (<b data-breakpoint-output></b>)</pre>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
+  <script type="text/javascript" src="../build/bundle.js"></script>
+</body>
+</html>

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -9,3 +9,100 @@ Right now use the es6 [Airbnb style guide](https://github.com/airbnb/javascript/
 ## Linting
 
 Linting is with eslint, and is coupled into the `npm test` script for convenience.
+
+## Modules
+
+### Breakpoint
+A helper which works with the breakpoints defined in the [SASS Variables](../sass/includes/_variables.scss) and the helpers defined in [Helpers](../sass/base/_helpers.scss) to allow synchronisation between screen-size specific functionality in JS and CSS :raised_hands:
+
+#### Quick start
+jQuery will need to be available globally. Simply import the module from Catchify:
+
+```javascript
+import {breakpoint} from 'catchify';
+
+(function example($) {
+  // Outputs screen size to element
+  // Bind this first to ensure the breakpointInit event is fired
+  $(window).on('breakpointChange breakpointInit', (e, data) => {
+    console(data.breakpoint);
+  });
+
+  // Initialise breakpoint
+  breakpoint.init();
+}(jQuery));
+```
+
+#### Methods
+
+##### Initialise breakpoint module
+```javascript
+breakpoint.init(settings);
+```
+The following settings can be overriden if desired
+```javascript
+{
+  // Template must be encapsulated HTML
+  template: '<span>',
+  // CSS properties appled to each element
+  styles: {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    width: '1px',
+    height: '1px',
+  },
+  // Combines with sizes to create (prefix + size)
+  classPrefix: 'visible-',
+  // The different sizes to create elements for
+  // Should map to breakpoints
+  breakpoints: ['xs', 'sm', 'md', 'lg'],
+  // The breakpoint attribute used to query visible element flag
+  dataAttrSelector: 'data-catchify-breakpoint',
+  // An event to fire when the breakpoint initialises
+  breakpointInitEvent: 'breakpointInit',
+  // An event to fire when the breakpoint changes
+  breakpointChangeEvent: 'breakpointChange',
+};
+```
+
+##### Get current breakpoint
+Returns the current breakpoint in range of options.breakpoints.
+```javascript
+// Returns String
+const currentBreakpoint = breakpoint.get();
+```
+
+##### Query current breakpoint
+Checks if the breakpoint is the same as that given.
+```javascript
+// Returns Boolean
+const isMobile = breakpoint.is('xs');
+```
+
+##### Query current breakpoint
+Checks if the breakpoint is not the same as that given.
+```javascript
+// Returns Boolean
+const isTabletOrBigger = breakpoint.not('xs');
+```
+
+#### Events
+
+##### breakpointInit
+Fired when the breakpoint module has finished setup
+```javascript
+$(window).on('breakpointInit', (e, data) {
+  // Outputs value of breakpoint.get()
+  console.log(data.breakpoint);
+});
+```
+
+##### breakpointChange
+Fired when a breakpoint has changed
+```javascript
+$(window).on('breakpointChange', (e, data) {
+  // Outputs value of breakpoint.get()
+  console.log(data.breakpoint);
+});
+```

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,0 +1,11 @@
+# Catchify JavaScript
+
+Like the SASS, JavaScript should be genuinely useful across projects.  A module like `client-name-news-filtering.js` doesn't really fly in Catchify.  Is it a bird, is it a plane?  Nope, it doesn't fly... :boom:
+
+## Coding Standards
+
+Right now use the es6 [Airbnb style guide](https://github.com/airbnb/javascript/tree/master/linters).
+
+## Linting
+
+Linting is with eslint, and is coupled into the `npm test` script for convenience.

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -4,11 +4,12 @@ import breakpoint from './lib/breakpoint';
   // Bind jQuery to $ global
   window.$ = $;
 
+  // Outputs screen size to element
+  // Bind this first to ensure the breakpointInit event is fired
+  $(window).on('breakpointChange breakpointInit', (e, data) => {
+    $('[data-breakpoint-output]').text(data.breakpoint);
+  });
+
   // Test screen size helper
   breakpoint.init();
-
-  // Outputs screen size to element
-  breakpoint.onChange((newSize) => {
-    $('[data-breakpoint-output]').text(newSize);
-  });
 }(jQuery));

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,15 +1,5 @@
 import breakpoint from './lib/breakpoint';
 
-(function index($) {
-  // Bind jQuery to $ global
-  window.$ = $;
-
-  // Outputs screen size to element
-  // Bind this first to ensure the breakpointInit event is fired
-  $(window).on('breakpointChange breakpointInit', (e, data) => {
-    $('[data-breakpoint-output]').text(data.breakpoint);
-  });
-
-  // Test screen size helper
-  breakpoint.init();
-}(jQuery));
+export default {
+  breakpoint,
+};

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,0 +1,14 @@
+import breakpoint from './lib/breakpoint';
+
+(function index($) {
+  // Bind jQuery to $ global
+  window.$ = $;
+
+  // Test screen size helper
+  breakpoint.init();
+
+  // Outputs screen size to element
+  breakpoint.onChange((newSize) => {
+    $('[data-breakpoint-output]').text(newSize);
+  });
+}(jQuery));

--- a/javascript/lib/breakpoint.js
+++ b/javascript/lib/breakpoint.js
@@ -1,0 +1,108 @@
+/**
+ * Helper module for querying the current break point.
+ *
+ * Rather than returning a width, or indeed relying on one, we use visibility
+ * helper classes to tie into how the breakpoints are calculated with media queries.
+ *
+ * This is important as it ensures consistency when adding JS functionality at
+ * a certain breakpoint
+ */
+
+/**
+ * These are the default used to setup this helper module
+ * @type {Object}
+ */
+const defaultOptions = {
+  // Template must be encapsulated HTML
+  template: '<span>',
+  // CSS properties appled to each element
+  styles: {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    width: '1px',
+    height: '1px',
+  },
+  // Combines with sizes to create (prefix + size)
+  classPrefix: 'visible-',
+  // The different sizes to create elements for
+  // Should map to breakpoints
+  breakpoints: ['xs', 'sm', 'md', 'lg'],
+  // The breakpoint attribute used to query visible element flag
+  dataAttrSelector: 'data-catchify-breakpoint',
+};
+
+const breakpoint = {
+  /**
+   * Sets up the breakpoint helper, implementing flag elements into the DOM
+   * @param  {Object}   options
+   */
+  init(options = {}) {
+    // Combine user given options with defaults
+    this.options = Object.assign(defaultOptions, options);
+
+    // For every given breakpoints create a helper flag element
+    this.options.breakpoints.forEach((size) => {
+      const $element = $(this.options.template);
+
+      // Setup element properties
+      $element.css(this.options.styles);
+      $element.attr('class', this.options.classPrefix + size);
+      $element.attr(this.options.dataAttrSelector, size);
+
+      // Add element to body
+      $('body').append($element);
+    });
+  },
+
+  /**
+   * Returns the current breakpoint in range of options.breakpoints
+   * @return {String}
+   */
+  get() {
+    return $(`[${this.options.dataAttrSelector}]:visible:last`)
+             .attr(this.options.dataAttrSelector);
+  },
+
+  /**
+   * Checks if the breakpoint is the same as that given
+   * @param  {String}  size
+   * @return {Boolean}
+   */
+  is(size) {
+    return this.get() === size;
+  },
+
+  /**
+   * Checks if the breakpoint is not the same as that given
+   * @param  {String}  size
+   * @return {Boolean}
+   */
+  not(size) {
+    return !this.is(size);
+  },
+
+  /**
+   * Provides an interface for reacting to breakpoint changes using a
+   * deferred resize event and a checkt to see if the breakpoint has changed
+   *
+   * @param  {Function} resized
+   */
+  onChange(resized) {
+    resized(this.get());
+
+    $(window).resize(() => {
+      this.changeTimeoutId = setTimeout(() => {
+        clearTimeout(this.changeTimeoutId);
+
+        if (this.lastCalculatedSize !== this.get()) {
+          this.lastCalculatedSize = this.get();
+
+          resized(this.lastCalculatedSize);
+        }
+      }, this.options.resizeTimeout);
+    });
+  },
+};
+
+export default breakpoint;

--- a/javascript/lib/breakpoint.js
+++ b/javascript/lib/breakpoint.js
@@ -45,7 +45,7 @@ const breakpoint = {
     let changeTimeoutId;
     let lastCalculatedSize;
     // Combine user given options with defaults
-    this.options = Object.assign(defaultOptions, options);
+    this.options = Object.assign({}, defaultOptions, options);
 
     // For every given breakpoints create a helper flag element
     this.options.breakpoints.forEach((size) => {

--- a/javascript/tests/README.md
+++ b/javascript/tests/README.md
@@ -1,0 +1,7 @@
+# Catchify JavaScript Tests
+
+Ideally we should be writing tests for all modules in the [lib](../lib) directory. Tests are written with [Jasmine](https://jasmine.github.io/2.1/node.html) using Babel to shim in CLI es65 goodness so we can unit test the modules and [jsdom](https://github.com/tmpvar/jsdom) to mock a browser environment.
+
+Have a look at the [config file](./jasmine.json) for more information on initial setup and the [dom.js](./specs/helpers/dom.js) file to see how we're mocking the environment.
+
+All test specs should go in the [/specs](./specs) directory and have a name like so `${MODULE_NAME}.spec.js`.  Feel free to be as descriptive with your tests as possible with as many `describe('...` calls as you like.  Also ensure that all test cases use sentence case with full stop at the end.

--- a/javascript/tests/jasmine.json
+++ b/javascript/tests/jasmine.json
@@ -1,0 +1,12 @@
+{
+  "spec_dir": "javascript/tests/specs",
+  "spec_files": [
+    "**/*.spec.js"
+  ],
+  "helpers": [
+    "../../node_modules/babel-core/register.js",
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/javascript/tests/jasmine.json
+++ b/javascript/tests/jasmine.json
@@ -4,7 +4,6 @@
     "**/*.spec.js"
   ],
   "helpers": [
-    "../../node_modules/babel-core/register.js",
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,

--- a/javascript/tests/specs/breakpoint.spec.js
+++ b/javascript/tests/specs/breakpoint.spec.js
@@ -1,0 +1,80 @@
+import breakpoint from '../../lib/breakpoint';
+
+/**
+ * Set of tests to check the basic API for the breakpoint module
+ */
+describe('Breakpoint module.', function() {
+  // Remove breakpoints after every test
+  afterEach(function() {
+    $(`[${breakpoint.options.dataAttrSelector}]`).remove();
+  });
+
+  describe('Breakpoint initialisation.', function() {
+    it('Should initialise without options.', function() {
+      breakpoint.init();
+
+      expect($(`[${breakpoint.options.dataAttrSelector}]`).length).toBe(4);
+    });
+
+    it('Should initialise with options.', function() {
+      breakpoint.init({
+        breakpoints: ['xss'],
+        dataAttrSelector: 'data-foo',
+        classPrefix: 'foo-'
+      });
+
+      expect(breakpoint.options.dataAttrSelector).toBe('data-foo');
+      expect($('[data-foo]').length).toBe(1);
+      expect($('[data-foo]:last').attr('data-foo', 'xss'));
+      expect($('[data-foo]:last').attr('class', 'foo-xss'));
+    });
+  });
+
+  describe('Breakpoint methods.', function() {
+    it('Should query the breakpoint accurately.', function() {
+      breakpoint.init();
+
+      expect(breakpoint.get()).toBe('lg');
+      expect(breakpoint.is('lg')).toBe(true);
+      expect(breakpoint.not('md')).toBe(true);
+    });
+  });
+
+  describe('Breakpoint queries.', function() {
+    it('Should query the lg breakpoint accurately.', function() {
+      breakpoint.init();
+
+      expect(breakpoint.get()).toBe('lg');
+      expect(breakpoint.is('lg')).toBe(true);
+      expect(breakpoint.not('md')).toBe(true);
+    });
+
+    it('Should query the md breakpoint accurately.', function() {
+      breakpoint.init();
+
+      // Here, we can't rely on media queries so we manually augment visibility
+      $(`[${breakpoint.options.dataAttrSelector}="md"]`).nextAll().hide();
+      expect(breakpoint.get()).toBe('md');
+      expect(breakpoint.is('md')).toBe(true);
+      expect(breakpoint.not('lg')).toBe(true);
+    });
+
+    it('Should query the sm breakpoint accurately.', function() {
+      breakpoint.init();
+
+      $(`[${breakpoint.options.dataAttrSelector}="sm"]`).nextAll().hide();
+      expect(breakpoint.get()).toBe('sm');
+      expect(breakpoint.is('sm')).toBe(true);
+      expect(breakpoint.not('md')).toBe(true);
+    });
+
+    it('Should query the xs breakpoint accurately.', function() {
+      breakpoint.init();
+
+      $(`[${breakpoint.options.dataAttrSelector}="xs"]`).nextAll().hide();
+      expect(breakpoint.get()).toBe('xs');
+      expect(breakpoint.is('xs')).toBe(true);
+      expect(breakpoint.not('sm')).toBe(true);
+    });
+  });
+});

--- a/javascript/tests/specs/helpers/dom.js
+++ b/javascript/tests/specs/helpers/dom.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const jsdom = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+beforeAll(function (done) {
+  jsdom.env(
+    '<p>Boom</p>',
+    ['http://code.jquery.com/jquery.js'],
+    function (err, window) {
+      assert.equal(null, err);
+
+      global.window = window;
+      global.document = window.document;
+      global.$ = window.jQuery;
+
+      $.expr.pseudos.hidden = function(elem) {
+        return elem.style.display === 'none';
+      }
+
+      fs.readFile(path.join(__dirname, '/../../../../build/styles.css'), 'utf8', function(err, data) {
+        $('head').append('<style type="text/css">');
+        $('style').html(data);
+        done();
+      });
+    }
+  );
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "A collection of front end files to kickstart projects",
   "scripts": {
-    "build:js": "node ./node_modules/.bin/browserify -t [ babelify --presets [ es2015 ] ] ./javascript/index.js -o ./build/bundle.js",
+    "build:js": "node ./node_modules/.bin/browserify -t [ babelify --presets [ es2015 ] ] ./javascript/index.js -o ./build/bundle.js && date +'Built: %T'",
     "build:css": "node ./node_modules/.bin/node-sass ./sass/styles.scss -o ./build/ --source-map true --include-path ./node_modules && node ./node_modules/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ./build/styles.css -d ./build/ && date +'Built: %T'",
     "build": "npm run build:css && npm run build:js",
     "test": "npm run build && node ./node_modules/.bin/eslint ."

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "catchify",
   "version": "1.0.3",
   "description": "A collection of front end files to kickstart projects",
+  "main": "javascript/index.js",
   "scripts": {
-    "build:js": "node ./node_modules/.bin/browserify -t [ babelify --presets [ es2015 ] ] ./javascript/index.js -o ./build/bundle.js && date +'Built: %T'",
-    "build:css": "node ./node_modules/.bin/node-sass ./sass/styles.scss -o ./build/ --source-map true --include-path ./node_modules && node ./node_modules/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ./build/styles.css -d ./build/ && date +'Built: %T'",
+    "build:js": "node scripts/js.js ./node_modules ./javascript/index.js ./build/bundle.js",
+    "build:css": "node scripts/css.js ./node_modules ./sass/styles.scss ./build ./build/styles.css",
     "build": "npm run build:css && npm run build:js",
     "test:js": "JASMINE_CONFIG_PATH=javascript/tests/jasmine.json node ./node_modules/.bin/babel-node --presets node6 ./node_modules/.bin/jasmine",
     "test": "npm run build && node ./node_modules/.bin/eslint . && npm run test:js"
@@ -16,27 +17,38 @@
   "author": "Stuart Wilson <s.wilson@catchdigital.com>",
   "license": "MIT",
   "dependencies": {
-    "bootstrap-sass": "^3.3.6",
-    "node.normalize.scss": "^3.0.3"
-  },
-  "engines": {
-    "node": "~6.0.0"
-  },
-  "devDependencies": {
     "autoprefixer": "^6.7.3",
     "babel-cli": "^6.24.0",
     "babel-preset-es2015": "^6.24.0",
-    "babel-preset-node6": "^11.0.0",
     "babelify": "^7.3.0",
+    "bootstrap-sass": "^3.3.6",
     "browserify": "^14.1.0",
     "eslint": "^3.17.1",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
+    "log-timestamp": "^0.1.2",
+    "node-sass": "^4.5.0",
+    "node.normalize.scss": "^3.0.3",
+    "postcss-cli": "^3.0.0-beta"
+  },
+  "engines": {
+    "node": "~6.0.0"
+  },
+  "devDependencies": {
     "jasmine": "^2.5.3",
     "jsdom": "^9.12.0",
-    "node-sass": "^4.5.0",
-    "postcss-cli": "^3.0.0-beta"
+    "babel-preset-node6": "^11.0.0"
+  },
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "presets": "es2015"
+        }
+      ]
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
     "jasmine": "^2.5.3",
-    "jquery": "^3.1.1",
     "jsdom": "^9.12.0",
     "node-sass": "^4.5.0",
     "postcss-cli": "^3.0.0-beta"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build:js": "node ./node_modules/.bin/browserify -t [ babelify --presets [ es2015 ] ] ./javascript/index.js -o ./build/bundle.js && date +'Built: %T'",
     "build:css": "node ./node_modules/.bin/node-sass ./sass/styles.scss -o ./build/ --source-map true --include-path ./node_modules && node ./node_modules/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ./build/styles.css -d ./build/ && date +'Built: %T'",
     "build": "npm run build:css && npm run build:js",
-    "test": "npm run build && node ./node_modules/.bin/eslint ."
+    "test:js": "JASMINE_CONFIG_PATH=javascript/tests/jasmine.json node ./node_modules/.bin/jasmine",
+    "test": "npm run build && node ./node_modules/.bin/eslint . && npm run test:js"
   },
   "repository": {
     "type": "git",
@@ -32,6 +33,9 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
+    "jasmine": "^2.5.3",
+    "jquery": "^3.1.1",
+    "jsdom": "^9.12.0",
     "node-sass": "^4.5.0",
     "postcss-cli": "^3.0.0-beta"
   }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build:js": "node ./node_modules/.bin/browserify -t [ babelify --presets [ es2015 ] ] ./javascript/index.js -o ./build/bundle.js",
     "build:css": "node ./node_modules/.bin/node-sass ./sass/styles.scss -o ./build/ --source-map true --include-path ./node_modules && node ./node_modules/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ./build/styles.css -d ./build/ && date +'Built: %T'",
-    "build": "npm run build:js && npm run build:css",
-    "test": "npm install && npm run build"
+    "build": "npm run build:css && npm run build:js",
+    "test": "npm run build && node ./node_modules/.bin/eslint ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:js": "node ./node_modules/.bin/browserify -t [ babelify --presets [ es2015 ] ] ./javascript/index.js -o ./build/bundle.js && date +'Built: %T'",
     "build:css": "node ./node_modules/.bin/node-sass ./sass/styles.scss -o ./build/ --source-map true --include-path ./node_modules && node ./node_modules/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ./build/styles.css -d ./build/ && date +'Built: %T'",
     "build": "npm run build:css && npm run build:js",
-    "test:js": "JASMINE_CONFIG_PATH=javascript/tests/jasmine.json node ./node_modules/.bin/jasmine",
+    "test:js": "JASMINE_CONFIG_PATH=javascript/tests/jasmine.json node ./node_modules/.bin/babel-node --presets node6 ./node_modules/.bin/jasmine",
     "test": "npm run build && node ./node_modules/.bin/eslint . && npm run test:js"
   },
   "repository": {
@@ -26,6 +26,7 @@
     "autoprefixer": "^6.7.3",
     "babel-cli": "^6.24.0",
     "babel-preset-es2015": "^6.24.0",
+    "babel-preset-node6": "^11.0.0",
     "babelify": "^7.3.0",
     "browserify": "^14.1.0",
     "eslint": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "catchify",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A collection of front end files to kickstart projects",
   "scripts": {
-    "build": "node ./node_modules/.bin/node-sass ./sass/styles.scss -o ./build/ --source-map true --include-path ./node_modules && node ./node_modules/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ./build/styles.css -d ./build/ && date +'Built: %T'",
+    "build:js": "node ./node_modules/.bin/browserify -t [ babelify --presets [ es2015 ] ] ./javascript/index.js -o ./build/bundle.js",
+    "build:css": "node ./node_modules/.bin/node-sass ./sass/styles.scss -o ./build/ --source-map true --include-path ./node_modules && node ./node_modules/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ./build/styles.css -d ./build/ && date +'Built: %T'",
+    "build": "npm run build:js && npm run build:css",
     "test": "npm install && npm run build"
   },
   "repository": {
@@ -21,6 +23,15 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.7.3",
+    "babel-cli": "^6.24.0",
+    "babel-preset-es2015": "^6.24.0",
+    "babelify": "^7.3.0",
+    "browserify": "^14.1.0",
+    "eslint": "^3.17.1",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.0",
     "node-sass": "^4.5.0",
     "postcss-cli": "^3.0.0-beta"
   }

--- a/sass/base/_helpers.scss
+++ b/sass/base/_helpers.scss
@@ -57,27 +57,17 @@
   display: none;
 }
 
-.hidden-xs {
-  display: none;
-}
-
-.hidden-sm {
-  display: none;
-}
-
-.hidden-md {
+.hidden-xs,
+.hidden-sm,
+.hidden-md,
+.visible-sm,
+.visible-md,
+.visible-lg {
   display: none;
 }
 
 @media (min-width: $screen-sm-min) {
-  .visible-xs {
-    display: none;
-  }
-
-  .visible-sm {
-    display: block;
-  }
-
+  .visible-sm,
   .hidden-xs {
     display: block;
   }
@@ -96,10 +86,7 @@
 }
 
 @media (min-width: $screen-md-min) {
-  .visible-sm {
-    display: none;
-  }
-
+  .visible-md,
   .hidden-sm {
     display: block;
   }
@@ -110,10 +97,7 @@
 }
 
 @media (min-width: $screen-lg-min) {
-  .visible-md {
-    display: none;
-  }
-
+  .visible-lg,
   .hidden-md {
     display: block;
   }

--- a/scripts/css.js
+++ b/scripts/css.js
@@ -1,0 +1,16 @@
+require('log-timestamp');
+
+const exec = require('child_process').exec;
+const args = process.argv.slice(2);
+
+if (args.length < 4) {
+  console.error('\x1b[31m', 'Please provide paths to node_modules, the input and the output directory and output file');
+} else {
+  exec(`node ${args[0]}/.bin/node-sass ${args[1]} -o ${args[2]} --source-map true --include-path ${args[0]} && node ${args[0]}/.bin/postcss --use autoprefixer --autoprefixer.browsers 'IE 11, > 1%' ${args[3]} -d ${args[2]}`, (err) => {
+    if (err) {
+      return console.error('\x1b[31m', err);
+    }
+
+    console.log('\x1b[32m', `CSS built to file ${args[3]}`);
+  });
+}

--- a/scripts/js.js
+++ b/scripts/js.js
@@ -1,0 +1,16 @@
+require('log-timestamp');
+
+var exec = require('child_process').exec;
+var args = process.argv.slice(2);
+
+if (args.length < 3) {
+  console.error('\x1b[31m', 'Please provide paths to node_modules, the input and the output file');
+} else {
+  exec(`node ${args[0]}/.bin/browserify ${args[1]} -o ${args[2]}`, (err) => {
+    if (err) {
+      return console.error('\x1b[31m', err);
+    }
+
+    console.log('\x1b[32m', `JavaScript built to file ${args[2]}`);
+  });
+}


### PR DESCRIPTION
OK so this add JavaScript to the equation to allow use to write es6 in projects.

I've abstracted the build scripts to make sure they can be used when this is a dependency.  This is advantageous because:

- Less duplication of code
- Consistent build from Catchify to projects

In order to use this, one simply needs to go to the project they want to use:

1. Make `package.json` file
```
npm init
```

2. Then get Catchify:
```
npm install catchdigital/catchify --save
```

3. Create the recommended file structure (or not, your choice)

4. Build files from command line
```
// JavaScript
node ./node_modules/catchify/scripts/js.js ./node_modules ./index.js ./bundle.js

// CSS
node ./node_modules/catchify/scripts/css.js ./node_modules ./sass/styles.scss ./ ./styles.css
```

💥  Add the above scripts to your project `package.json` file for ease of use from the command line